### PR TITLE
Sdl2 support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,64 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'wasmstation'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=wasmstation",
+                    "--package=wasmstation-cli"
+                ],
+                "filter": {
+                    "name": "wasmstation",
+                    "kind": "bin"
+                }
+            },
+            "args": ["../w4-hello-world/target/wasm32-unknown-unknown/release/cart.wasm"],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'wasmstation'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=wasmstation",
+                    "--package=wasmstation-cli"
+                ],
+                "filter": {
+                    "name": "wasmstation",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'wasmstation'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=wasmstation"
+                ],
+                "filter": {
+                    "name": "wasmstation",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
     let renderer = match ProxyRenderer::from_name(&args.renderer, args.display_scale as u32) {
         Ok(r) => r,
         Err(_) => {
-            eprintln!("renderer '{}' is unknown", args.renderer);
+            eprintln!("renderer '{}' is unknown, supported renderers are: {:?}", args.renderer, ProxyRenderer::names());
             std::process::exit(1)
         }
     };

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,20 +18,22 @@ struct Args {
     #[argh(
         option,
         short = 'r',
-        default = "String::from(\"wgpu\")",
         description = "renderer to use"
     )]
-    renderer: String,
+    renderer: Option<String>,
 }
 
 fn main() {
     let args: Args = argh::from_env();
+    let renderer_name = args.renderer.as_ref()
+        .map(|s|String::from(s))
+        .unwrap_or_else(||String::from(ProxyRenderer::default_name()));
     let wasm_bytes = fs::read(&args.path).expect("failed to read game");
 
-    let renderer = match ProxyRenderer::from_name(&args.renderer, args.display_scale as u32) {
+    let renderer = match ProxyRenderer::from_name(&renderer_name, args.display_scale as u32) {
         Ok(r) => r,
         Err(_) => {
-            eprintln!("renderer '{}' is unknown, supported renderers are: {:?}", args.renderer, ProxyRenderer::names());
+            eprintln!("renderer '{}' is unknown, supported renderers are: {:?}", &renderer_name, ProxyRenderer::names());
             std::process::exit(1)
         }
     };

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::PathBuf};
 
 use argh::FromArgs;
-use wasmstation::{backend::WasmerBackend, renderer::{WgpuRenderer, Sdl2Renderer}};
+use wasmstation::{backend::WasmerBackend, renderer::ProxyRenderer};
 
 #[derive(FromArgs)]
 #[argh(description = "Run wasm4 compatible games.")]
@@ -15,16 +15,29 @@ struct Args {
         description = "scale factor for the window"
     )]
     display_scale: u8,
+    #[argh(
+        option,
+        short = 'r',
+        default = "String::from(\"wgpu\")",
+        description = "renderer to use"
+    )]
+    renderer: String,
 }
 
 fn main() {
     let args: Args = argh::from_env();
     let wasm_bytes = fs::read(&args.path).expect("failed to read game");
 
+    let renderer = match ProxyRenderer::from_name(&args.renderer, args.display_scale as u32) {
+        Ok(r) => r,
+        Err(_) => {
+            eprintln!("renderer '{}' is unknown", args.renderer);
+            std::process::exit(1)
+        }
+    };
+    
     wasmstation::launch(
         WasmerBackend::new(&wasm_bytes).unwrap(),
-        Sdl2Renderer {
-            //display_scale: args.display_scale as u32,
-        },
+        renderer
     );
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::PathBuf};
 
 use argh::FromArgs;
-use wasmstation::{backend::WasmerBackend, renderer::WgpuRenderer};
+use wasmstation::{backend::WasmerBackend, renderer::{WgpuRenderer, Sdl2Renderer}};
 
 #[derive(FromArgs)]
 #[argh(description = "Run wasm4 compatible games.")]
@@ -23,8 +23,8 @@ fn main() {
 
     wasmstation::launch(
         WasmerBackend::new(&wasm_bytes).unwrap(),
-        WgpuRenderer {
-            display_scale: args.display_scale as u32,
+        Sdl2Renderer {
+            //display_scale: args.display_scale as u32,
         },
     );
 }

--- a/wasmstation/Cargo.toml
+++ b/wasmstation/Cargo.toml
@@ -19,10 +19,13 @@ byteorder = "1.4.3"
 # wasmer
 wasmer = { version = "3.0", optional = true }
 
+# sdl2
+sdl2 = { version = "0.35", optional = true }
+
 [features]
-default = ["wasmer-backend", "wgpu-renderer"] # this is still up for debate obviously
+default = ["wasmer-backend", "wgpu-renderer", "sdl2-renderer"] # this is still up for debate obviously
 wgpu-renderer = ["wgpu", "winit", "pollster"]
-# sdl2-backend = []
+sdl2-renderer = ["sdl2"]
 wasmer-backend = ["wasmer"]
 # wasm3-backend = []
 

--- a/wasmstation/Cargo.toml
+++ b/wasmstation/Cargo.toml
@@ -23,7 +23,11 @@ wasmer = { version = "3.0", optional = true }
 sdl2 = { version = "0.35", optional = true }
 
 [features]
-default = ["wasmer-backend", "wgpu-renderer", "sdl2-renderer"] # this is still up for debate obviously
+default = [
+    "wasmer-backend", 
+    "wgpu-renderer", 
+    "sdl2-renderer",
+] # this is still up for debate obviously
 wgpu-renderer = ["wgpu", "winit", "pollster"]
 sdl2-renderer = ["sdl2"]
 wasmer-backend = ["wasmer"]

--- a/wasmstation/src/renderer/mod.rs
+++ b/wasmstation/src/renderer/mod.rs
@@ -3,3 +3,10 @@ mod wgpu;
 
 #[cfg(feature = "wgpu-renderer")]
 pub use self::wgpu::WgpuRenderer;
+
+
+#[cfg(feature = "sdl2-renderer")]
+mod sdl2;
+
+#[cfg(feature = "sdl2-renderer")]
+pub use self::sdl2::Sdl2Renderer;

--- a/wasmstation/src/renderer/mod.rs
+++ b/wasmstation/src/renderer/mod.rs
@@ -10,3 +10,6 @@ mod sdl2;
 
 #[cfg(feature = "sdl2-renderer")]
 pub use self::sdl2::Sdl2Renderer;
+
+mod proxy;
+pub use proxy::ProxyRenderer;

--- a/wasmstation/src/renderer/proxy/mod.rs
+++ b/wasmstation/src/renderer/proxy/mod.rs
@@ -1,0 +1,32 @@
+use crate::Renderer;
+
+use super::{WgpuRenderer, Sdl2Renderer};
+
+
+pub enum ProxyRenderer {
+    #[cfg(feature="wgpu-renderer")]
+    Wgpu(WgpuRenderer),
+    #[cfg(feature="sdl2-renderer")]
+    Sdl2(Sdl2Renderer),
+}
+
+impl ProxyRenderer {
+    pub fn from_name(name: &str, display_scale: u32) -> Result<ProxyRenderer,()> {
+        match name {
+            "wgpu" => Ok(ProxyRenderer::Wgpu(WgpuRenderer{display_scale})),
+            "sdl2" => Ok(ProxyRenderer::Sdl2(Sdl2Renderer{})),
+            _ => Err(())
+        }
+    }
+}
+
+impl Renderer for ProxyRenderer {
+    fn present(self, b: impl crate::Backend + 'static) {
+        match self {
+            #[cfg(feature="wgpu-renderer")]
+            Self::Wgpu(r) => r.present(b),
+            #[cfg(feature="sdl2-renderer")]
+            Self::Sdl2(r) => r.present(b),
+        }
+    }
+}

--- a/wasmstation/src/renderer/proxy/mod.rs
+++ b/wasmstation/src/renderer/proxy/mod.rs
@@ -1,6 +1,10 @@
 use crate::Renderer;
 
-use super::{WgpuRenderer, Sdl2Renderer};
+#[cfg(feature="wgpu-renderer")]
+use super::WgpuRenderer;
+#[cfg(feature="sdl2-renderer")]
+use super::Sdl2Renderer;
+
 
 
 pub enum ProxyRenderer {
@@ -10,15 +14,25 @@ pub enum ProxyRenderer {
     Sdl2(Sdl2Renderer),
 }
 
-const PROXY_RENDERER_NAMES: &[&str] = &["wgpu", "sdl2"];
+const PROXY_RENDERER_NAMES: &[&str] = &[
+    #[cfg(feature="wgpu-renderer")]
+    "wgpu", 
+    #[cfg(feature="sdl2-renderer")]
+    "sdl2",
+];
 impl ProxyRenderer {
 
     pub fn from_name(name: &str, display_scale: u32) -> Result<ProxyRenderer,()> {
         match name {
+            #[cfg(feature="wgpu-renderer")]
             "wgpu" => Ok(ProxyRenderer::Wgpu(WgpuRenderer{display_scale})),
+            #[cfg(feature="sdl2-renderer")]
             "sdl2" => Ok(ProxyRenderer::Sdl2(Sdl2Renderer{})),
             _ => Err(())
         }
+    }
+    pub fn default_name() -> &'static str {
+        ProxyRenderer::names()[0]
     }
     pub fn names() -> &'static [&'static str] {
         return PROXY_RENDERER_NAMES;

--- a/wasmstation/src/renderer/proxy/mod.rs
+++ b/wasmstation/src/renderer/proxy/mod.rs
@@ -10,13 +10,19 @@ pub enum ProxyRenderer {
     Sdl2(Sdl2Renderer),
 }
 
+const PROXY_RENDERER_NAMES: &[&str] = &["wgpu", "sdl2"];
 impl ProxyRenderer {
+
     pub fn from_name(name: &str, display_scale: u32) -> Result<ProxyRenderer,()> {
         match name {
             "wgpu" => Ok(ProxyRenderer::Wgpu(WgpuRenderer{display_scale})),
             "sdl2" => Ok(ProxyRenderer::Sdl2(Sdl2Renderer{})),
             _ => Err(())
         }
+    }
+    pub fn names() -> &'static [&'static str] {
+        return PROXY_RENDERER_NAMES;
+
     }
 }
 

--- a/wasmstation/src/renderer/sdl2/mod.rs
+++ b/wasmstation/src/renderer/sdl2/mod.rs
@@ -1,0 +1,105 @@
+use std::time::Duration;
+
+use sdl2::{pixels::{PixelFormatEnum, Color, Palette}, surface::Surface, rect::Rect, event::Event, keyboard::Keycode};
+
+use crate::{Renderer, wasm4::{SCREEN_SIZE, FRAMEBUFFER_ADDR, FRAMEBUFFER_SIZE}};
+
+
+pub struct Sdl2Renderer {}
+
+
+
+fn expand_fb_to_index8(fbtexdata: &mut [u8]) {
+    assert!(fbtexdata.len() %4 == 0);
+
+    for n in (0..fbtexdata.len()/4).rev() {
+        let buf = fbtexdata[n];
+        let m = 4*n+3;
+        fbtexdata[m] = buf >> 6;
+        let m = m-1;
+        fbtexdata[m] = (buf >> 4) & 0b00000011;
+        let m = m-1;
+        fbtexdata[m] = (buf >> 2) & 0b00000011;
+        let m = m-1;
+        fbtexdata[m] = buf & 0b00000011;
+    }
+}
+
+#[test]
+fn test_expand_fb_to_index8() {
+    let mut testfb = [0b11100100, 0b01100011, 0, 0, 0, 0, 0, 0];
+    expand_fb_to_index8(&mut testfb);
+
+    assert!(testfb == [
+        0b00,
+        0b01,
+        0b10,
+        0b11,
+        0b11,
+        0b00,
+        0b10,
+        0b01
+    ]);
+}
+
+impl Renderer for Sdl2Renderer {
+    fn present(self, mut backend: impl crate::Backend + 'static) {
+        let sdl_context = sdl2::init().unwrap();
+        let video_subsystem = sdl_context.video().unwrap();
+     
+        let window = video_subsystem.window("WASM Station", 3*SCREEN_SIZE, 3*SCREEN_SIZE)
+            .position_centered()
+            .build()
+            .unwrap();
+     
+        let mut canvas = window.into_canvas().build().unwrap();
+     
+        let mut surface = Surface::new(SCREEN_SIZE, SCREEN_SIZE, PixelFormatEnum::Index8).unwrap();
+        let tc = canvas.texture_creator();
+    
+        canvas.set_draw_color(Color::RGB(0, 255, 255));
+        canvas.clear();
+        canvas.present();
+        let mut event_pump = sdl_context.event_pump().unwrap();
+    
+        let mut raw_colors = [0xffu8;4*4];
+        let mut colors = Vec::with_capacity(256);
+        colors.resize(256, Color::RGB(0,0,0));
+    
+        'running: loop {
+    
+            backend.call_update();
+    
+            // read palette for this frame
+            for c in 0..4 {
+                colors[c] = Color::RGB(raw_colors[3*c+0], raw_colors[3*c+1], raw_colors[3*c+2])
+            }
+    
+            let fbdata =surface.without_lock_mut().unwrap();
+            let fbdata: &mut [u8;FRAMEBUFFER_SIZE] = (&mut fbdata[0..FRAMEBUFFER_SIZE]).try_into().unwrap();
+            backend.read_screen(fbdata, &mut raw_colors);
+            expand_fb_to_index8(fbdata);
+    
+    
+            let palette = Palette::with_colors(&colors).unwrap();
+            surface.set_palette(&palette).unwrap();
+            
+            let fb_tex = tc.create_texture_from_surface(&surface).unwrap();
+            canvas.copy(&fb_tex, None, Some(Rect::new(0, 0, 3*SCREEN_SIZE, 3*SCREEN_SIZE))).unwrap();
+    
+            for event in event_pump.poll_iter() {
+                match event {
+                    Event::Quit {..} |
+                    Event::KeyDown { keycode: Some(Keycode::Escape), .. } => {
+                        break 'running
+                    },
+                    _ => ()
+                }
+            }
+            // The rest of the game loop goes here...
+    
+            canvas.present();
+            ::std::thread::sleep(Duration::new(0, 1_000_000_000u32 / 60));
+        }
+    }
+}

--- a/wasmstation/src/renderer/sdl2/mod.rs
+++ b/wasmstation/src/renderer/sdl2/mod.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use sdl2::{pixels::{PixelFormatEnum, Color, Palette}, surface::Surface, rect::Rect, event::Event, keyboard::Keycode};
 
-use crate::{Renderer, wasm4::{SCREEN_SIZE, FRAMEBUFFER_ADDR, FRAMEBUFFER_SIZE}};
+use crate::{Renderer, wasm4::{SCREEN_SIZE, FRAMEBUFFER_SIZE}};
 
 
 pub struct Sdl2Renderer {}


### PR DESCRIPTION
* add `-r <renderer>` option
* implemented via additional ProxyRenderer
* initially checked whether to implement this via `Box<dyn Renderer>`, but that's currently not possible because `Renderer` is not object safe. But an enum will do just fine for now.