### PR TITLE
ProxyRenderer -> DefaultRenderer

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,6 +9,12 @@ edition = "2021"
 argh = "0.1"
 wasmstation = { path = "../wasmstation" }
 
+[features]
+default = ["sdl2"]
+
+wgpu = ["wasmstation/wgpu-renderer"]
+sdl2 = ["wasmstation/sdl2-renderer"]
+
 [[bin]]
 name = "wasmstation"
 path = "src/main.rs"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,45 +1,21 @@
 use std::{fs, path::PathBuf};
 
 use argh::FromArgs;
-use wasmstation::{backend::WasmerBackend, renderer::ProxyRenderer};
+use wasmstation::{backend::WasmerBackend, renderer::DefaultRenderer};
 
 #[derive(FromArgs)]
 #[argh(description = "Run wasm4 compatible games.")]
 struct Args {
     #[argh(positional)]
     path: PathBuf,
-    #[argh(
-        option,
-        short = 's',
-        default = "3",
-        description = "scale factor for the window"
-    )]
-    display_scale: u8,
-    #[argh(
-        option,
-        short = 'r',
-        description = "renderer to use"
-    )]
-    renderer: Option<String>,
 }
 
 fn main() {
     let args: Args = argh::from_env();
-    let renderer_name = args.renderer.as_ref()
-        .map(|s|String::from(s))
-        .unwrap_or_else(||String::from(ProxyRenderer::default_name()));
     let wasm_bytes = fs::read(&args.path).expect("failed to read game");
-
-    let renderer = match ProxyRenderer::from_name(&renderer_name, args.display_scale as u32) {
-        Ok(r) => r,
-        Err(_) => {
-            eprintln!("renderer '{}' is unknown, supported renderers are: {:?}", &renderer_name, ProxyRenderer::names());
-            std::process::exit(1)
-        }
-    };
     
     wasmstation::launch(
         WasmerBackend::new(&wasm_bytes).unwrap(),
-        renderer
+        DefaultRenderer::default(),
     );
 }

--- a/wasmstation/Cargo.toml
+++ b/wasmstation/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 # general
 anyhow = "1.0"
 bytemuck = "1.12"
+cfg-if = "1"
 
 # wgpu
 winit = { version = "0.27", optional = true, default-features = false, features = ["x11"] }
@@ -23,11 +24,8 @@ wasmer = { version = "3.0", optional = true }
 sdl2 = { version = "0.35", optional = true }
 
 [features]
-default = [
-    "wasmer-backend", 
-    "wgpu-renderer", 
-    "sdl2-renderer",
-] # this is still up for debate obviously
+default = ["wasmer-backend"]
+
 wgpu-renderer = ["wgpu", "winit", "pollster"]
 sdl2-renderer = ["sdl2"]
 wasmer-backend = ["wasmer"]

--- a/wasmstation/src/renderer/mod.rs
+++ b/wasmstation/src/renderer/mod.rs
@@ -1,15 +1,15 @@
-#[cfg(feature = "wgpu-renderer")]
-mod wgpu;
+cfg_if::cfg_if! {
+    if #[cfg(all(feature = "wgpu-renderer", feature = "sdl2-renderer"))] {
+        compile_error!("default renderer cannot be both wgpu and sdl2");
+    } else if #[cfg(feature = "wgpu-renderer")] {
+        mod wgpu;
+        pub use self::wgpu::WgpuRenderer;
 
-#[cfg(feature = "wgpu-renderer")]
-pub use self::wgpu::WgpuRenderer;
+        pub type DefaultRenderer = WgpuRenderer;
+    } else if #[cfg(feature = "sdl2-renderer")] {
+        mod sdl2;
+        pub use self::sdl2::Sdl2Renderer;
 
-
-#[cfg(feature = "sdl2-renderer")]
-mod sdl2;
-
-#[cfg(feature = "sdl2-renderer")]
-pub use self::sdl2::Sdl2Renderer;
-
-mod proxy;
-pub use proxy::ProxyRenderer;
+        pub type DefaultRenderer = Sdl2Renderer;
+    }
+}

--- a/wasmstation/src/renderer/sdl2/mod.rs
+++ b/wasmstation/src/renderer/sdl2/mod.rs
@@ -4,10 +4,8 @@ use sdl2::{pixels::{PixelFormatEnum, Color, Palette}, surface::Surface, rect::Re
 
 use crate::{Renderer, wasm4::{SCREEN_SIZE, FRAMEBUFFER_SIZE}};
 
-
-pub struct Sdl2Renderer {}
-
-
+#[derive(Default)]
+pub struct Sdl2Renderer;
 
 fn expand_fb_to_index8(fbtexdata: &mut [u8]) {
     assert!(fbtexdata.len() %4 == 0);

--- a/wasmstation/src/renderer/wgpu/mod.rs
+++ b/wasmstation/src/renderer/wgpu/mod.rs
@@ -377,6 +377,12 @@ pub struct WgpuRenderer {
     pub display_scale: u32,
 }
 
+impl Default for WgpuRenderer {
+    fn default() -> Self {
+        Self { display_scale: 3 }
+    }
+}
+
 impl Renderer for WgpuRenderer {
     fn present(self, mut backend: impl crate::Backend + 'static) {
         let event_loop = EventLoop::new();


### PR DESCRIPTION
I don't think users of the library will need both wgpu and sdl2 renderers compiled into their executable, the only time I can see wanting to quickly switch between renderers is for development, where we will already be frequently recompiling the code. Because of this, I've used `cfg-if` (a very common and lightweight macro) to create `DefaultRenderer`, which serves the same purpose as `ProxyRenderer`. `DefaultRenderer` automatically compiles to whatever renderer you have enabled at that moment. I believe `DefaultRenderer` will be more convenient and intuitive for the users of the library.

Functionally, it changes very little, while making the binaries much lighter:

Instead of this:
```shell
$ cargo r -- /path/to/cart.wasm -r {renderer}
```

We do this:
```shell
$ cargo r --features={renderer} -- /path/to/cart.wasm
```

In the code, all we have to do is call `DefaultRenderer::default()`. I've even kept sdl2 as default for the cli 👍🏽.