### PR TITLE
Add faster `vline` and `hline` functions

### DIFF
--- a/wasmstation/src/console/fb.rs
+++ b/wasmstation/src/console/fb.rs
@@ -638,6 +638,8 @@ fn test_conv_1bpp_to_2bpp() {
     assert_eq!(0b01_01_01_01_00_00_00_00, conv_1bpp_to_2bpp(0b0000000011110000));
 }
 
+/// Returns a Some<u8> palette address if the draw color at the index is opaque,
+/// and None if transparent.
 fn remap_draw_color(draw_color_idx: u8, draw_colors: u16) -> Option<u8> {
     let draw_color = (draw_colors as u32 >> (draw_color_idx * 4)) & 0b111;
     if draw_color == 0 {

--- a/wasmstation/src/console/fb.rs
+++ b/wasmstation/src/console/fb.rs
@@ -763,8 +763,20 @@ fn hline_stroke<T: Screen>(
     y: i32,
     len: u32
 ) {
-    // TODO: create performant version of hline
-    line_stroke(screen, stroke, x, y, x+(len as i32)-1, y);
+    if y < 0 || y > T::HEIGHT as i32 {
+        return;
+    }
+
+    let start_x = x.max(0);
+    let end_x = (len as i32 + x).min(T::WIDTH as i32);
+
+    if start_x > end_x {
+        return;
+    }
+
+    for x in start_x..end_x {
+        set_pixel_impl(screen, x, y, stroke);
+    }
 }
 
 pub(crate) fn vline<T: Source<u8> + Sink<u8>>(
@@ -787,8 +799,20 @@ fn vline_stroke<T: Screen>(
     y: i32,
     len: u32
 ) {
-    // TODO: create performant version of hline
-    line_stroke(screen, stroke, x, y, x, y+(len as i32)-1);
+    if y + len as i32 <= 0 || x < 0 || x >= T::WIDTH as i32 {
+        return;
+    }
+
+    let start_y: i32 = y.max(0);
+    let end_y: i32 = (T::HEIGHT as i32).min(y + len as i32);
+
+    if start_y > end_y {
+        return;
+    }
+
+    for y in start_y..end_y {
+        set_pixel_impl(screen, x, y, stroke);
+    }
 }
 
 pub(crate) fn rect<T: Source<u8> + Sink<u8>>(


### PR DESCRIPTION
These new functions are much faster than the older line implementations. The native runtime's `hline` is *slightly* more efficient because it tries to update all the byte-aligned pixels directly with `memset`. We could definitely do this slightly better using `Sink::set_item_at` (or a new `Sink::fill_range`?), but I was unable to get it working today. Regardless, these new implementations are much better.