### PR TITLE
Refactor `renderer::launch` so it doesn't handle the filesystem.

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 argh = "0.1"
 wasmstation = { path = "../wasmstation" }
 pretty_env_logger = "0.4"
+log = "0.4"
 
 [[bin]]
 name = "wasmstation"

--- a/cli/src/disk.rs
+++ b/cli/src/disk.rs
@@ -1,0 +1,27 @@
+use std::{fs, io::ErrorKind, path::PathBuf};
+
+/// A simple reusable closure for writing a game disk to a file
+pub fn write(save_path: &PathBuf) -> impl Fn([u8; 1024]) -> Result<(), String> + '_ {
+    move |data: [u8; 1024]| fs::write(save_path, data).map_err(|err| err.to_string())
+}
+
+/// A simple reusable closure for reading a game disk from a file.
+pub fn read(save_path: &PathBuf) -> impl Fn() -> Result<[u8; 1024], String> + '_ {
+    move || {
+        // read bytes from disk and create new blank file if it doesn't exist.
+        let mut bytes: Vec<u8> = match fs::read(&save_path) {
+            Ok(bytes) => Ok(bytes),
+            Err(err) => match err.kind() {
+                ErrorKind::NotFound => fs::write(&save_path, vec![0])
+                    .map_err(|err| err.to_string())
+                    .map(|_| vec![0]),
+                _ => Err(err.to_string()),
+            },
+        }?;
+
+        bytes.resize(1024, 0);
+        bytes
+            .try_into()
+            .map_err(|_| "failed to resize save file to 1024".to_string())
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,9 +2,7 @@ use std::{env, ffi::OsStr, fs, path::PathBuf, process, str::FromStr};
 
 use argh::FromArgs;
 use log::error;
-use wasmstation::{backend::WasmerBackend, console::Console};
-
-mod disk;
+use wasmstation::{backend::WasmerBackend, console::Console, renderer::LaunchConfig};
 
 #[derive(FromArgs)]
 #[argh(description = "Run wasm4 compatible games.")]
@@ -65,10 +63,7 @@ fn run(args: Run) {
 
     wasmstation::launch(
         WasmerBackend::new(&wasm_bytes, &Console::new()).unwrap(),
-        disk::write(&save_path),
-        disk::read(&save_path),
-        args.display_scale,
-        &title,
+        LaunchConfig::from_savefile(save_path, args.display_scale, &title),
     )
     .unwrap();
 }
@@ -108,11 +103,6 @@ fn create(args: Create) {
     fs::write(base_dir.join("Cargo.toml"), cargo_toml).expect("create Cargo.toml");
     fs::write(base_dir.join("build.rs"), build_rs).expect("create build.rs");
     fs::write(base_dir.join("src").join("main.rs"), main_rs).expect("create main.rs");
-    fs::write(
-        base_dir.join("src").join("disk.rs"),
-        include_str!("disk.rs"),
-    )
-    .expect("create disk.rs");
     fs::copy(&args.cart, base_dir.join(&format!("{name}.wasm"))).expect("copy wasm cart");
 
     println!(

--- a/cli/src/template/main.rs
+++ b/cli/src/template/main.rs
@@ -7,8 +7,8 @@ fn main() {
     let save_path = PathBuf::from_str("{crate_name}.disk").expect("create save file path");
 
     wasmstation::launch(
-        WasmerBackend::new(&wasm_bytes, &Console::new()).unwrap(),
-        LaunchConfig::from_savefile(save_path, args.display_scale, &title),
+        WasmerBackend::precompiled(&WASM_BYTES, &Console::new()).unwrap(),
+        LaunchConfig::from_savefile(save_path, {window_scale}, "{crate_name}"),
     )
     .unwrap();
 }

--- a/cli/src/template/main.rs
+++ b/cli/src/template/main.rs
@@ -1,14 +1,19 @@
-use std::env;
-
+use std::{env, PathBuf};
 use wasmstation::{backend::WasmerBackend, console::Console};
+
+mod disk;
 
 const WASM_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/wasm.module"));
 
 fn main() {
+    let save_path = PathBuf::new("{crate_name}.disk");
+    
     wasmstation::launch(
         WasmerBackend::precompiled(WASM_BYTES, &Console::new()).unwrap(),
-        &env::current_dir().unwrap(),
+        disk::write(&save_path),
+        disk::read(&save_path),
         {window_scale},
+        "{crate_name}",
     )
     .unwrap();
 }

--- a/cli/src/template/main.rs
+++ b/cli/src/template/main.rs
@@ -1,8 +1,6 @@
 use std::{env, path::PathBuf, str::FromStr};
 use wasmstation::{backend::WasmerBackend, console::Console, renderer::LaunchConfig};
 
-mod disk;
-
 const WASM_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/wasm.module"));
 
 fn main() {

--- a/cli/src/template/main.rs
+++ b/cli/src/template/main.rs
@@ -1,5 +1,5 @@
 use std::{env, path::PathBuf, str::FromStr};
-use wasmstation::{backend::WasmerBackend, console::Console};
+use wasmstation::{backend::WasmerBackend, console::Console, renderer::LaunchConfig};
 
 mod disk;
 
@@ -7,13 +7,10 @@ const WASM_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/wasm.module"
 
 fn main() {
     let save_path = PathBuf::from_str("{crate_name}.disk").expect("create save file path");
-    
+
     wasmstation::launch(
-        WasmerBackend::precompiled(WASM_BYTES, &Console::new()).unwrap(),
-        disk::write(&save_path),
-        disk::read(&save_path),
-        {window_scale},
-        "{crate_name}",
+        WasmerBackend::new(&wasm_bytes, &Console::new()).unwrap(),
+        LaunchConfig::from_savefile(save_path, args.display_scale, &title),
     )
     .unwrap();
 }

--- a/cli/src/template/main.rs
+++ b/cli/src/template/main.rs
@@ -6,9 +6,13 @@ const WASM_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/wasm.module"
 fn main() {
     let save_path = PathBuf::from_str("{crate_name}.disk").expect("create save file path");
 
+    let mut config = LaunchConfig::from_path(&save_path);
+    config.display_scale = {window_scale};
+    config.title = "{crate_name}";
+
     wasmstation::launch(
         WasmerBackend::precompiled(&WASM_BYTES, &Console::new()).unwrap(),
-        LaunchConfig::from_savefile(save_path, {window_scale}, "{crate_name}"),
+        config,
     )
     .unwrap();
 }

--- a/cli/src/template/main.rs
+++ b/cli/src/template/main.rs
@@ -1,4 +1,4 @@
-use std::{env, PathBuf};
+use std::{env, path::PathBuf, str::FromStr};
 use wasmstation::{backend::WasmerBackend, console::Console};
 
 mod disk;
@@ -6,7 +6,7 @@ mod disk;
 const WASM_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/wasm.module"));
 
 fn main() {
-    let save_path = PathBuf::new("{crate_name}.disk");
+    let save_path = PathBuf::from_str("{crate_name}.disk").expect("create save file path");
     
     wasmstation::launch(
         WasmerBackend::precompiled(WASM_BYTES, &Console::new()).unwrap(),

--- a/wasmstation/Cargo.toml
+++ b/wasmstation/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0"
 bytemuck = "1.12"
 num-traits = "0.2"
 byteorder = "1.4"
+dirs = { version = "2.0", package = "dirs-next" }
 
 # renderer
 sdl2 = "0.35"

--- a/wasmstation/src/disk.rs
+++ b/wasmstation/src/disk.rs
@@ -1,13 +1,13 @@
 use std::{fs, io::ErrorKind, path::PathBuf};
 
 /// A simple reusable closure for writing a game disk to a file
-pub fn write(save_path: &PathBuf) -> impl Fn([u8; 1024]) -> Result<(), String> + '_ {
-    move |data: [u8; 1024]| fs::write(save_path, data).map_err(|err| err.to_string())
+pub fn write(save_path: PathBuf) -> Box<dyn Fn([u8; 1024]) -> Result<(), String>> {
+    Box::new(move |data: [u8; 1024]| fs::write(&save_path, data).map_err(|err| err.to_string()))
 }
 
 /// A simple reusable closure for reading a game disk from a file.
-pub fn read(save_path: &PathBuf) -> impl Fn() -> Result<[u8; 1024], String> + '_ {
-    move || {
+pub fn read(save_path: PathBuf) -> Box<dyn Fn() -> Result<[u8; 1024], String>> {
+    Box::new(move || {
         // read bytes from disk and create new blank file if it doesn't exist.
         let mut bytes: Vec<u8> = match fs::read(&save_path) {
             Ok(bytes) => Ok(bytes),
@@ -23,5 +23,5 @@ pub fn read(save_path: &PathBuf) -> impl Fn() -> Result<[u8; 1024], String> + '_
         bytes
             .try_into()
             .map_err(|_| "failed to resize save file to 1024".to_string())
-    }
+    })
 }

--- a/wasmstation/src/disk.rs
+++ b/wasmstation/src/disk.rs
@@ -1,18 +1,38 @@
-use std::{fs, io::ErrorKind, path::PathBuf};
+//! Configuration for accessing game save files.
 
-/// A simple reusable closure for writing a game disk to a file
-pub fn write(save_path: PathBuf) -> Box<dyn Fn([u8; 1024]) -> Result<(), String>> {
-    Box::new(move |data: [u8; 1024]| fs::write(&save_path, data).map_err(|err| err.to_string()))
+use std::{
+    fs,
+    io::{self, ErrorKind},
+    path::PathBuf,
+};
+
+/// Common trait for accessing game disks.
+pub trait DiskManager {
+    /// Retrieve disk bytes from the system's store.
+    fn read(&self) -> Result<[u8; 1024], String>;
+
+    /// Write disk bytes to the system's store.
+    fn write(&self, disk: [u8; 1024]) -> Result<(), String>;
 }
 
-/// A simple reusable closure for reading a game disk from a file.
-pub fn read(save_path: PathBuf) -> Box<dyn Fn() -> Result<[u8; 1024], String>> {
-    Box::new(move || {
-        // read bytes from disk and create new blank file if it doesn't exist.
-        let mut bytes: Vec<u8> = match fs::read(&save_path) {
+/// A DiskManager which saves the disk at `/path/to/cart/{cart_name}.disk`.
+pub struct Wasm4CompatibleDisk(PathBuf);
+
+impl Wasm4CompatibleDisk {
+    pub fn new(cart_location: &PathBuf) -> Self {
+        let mut disk_location = cart_location.clone();
+        disk_location.set_extension("disk");
+
+        Self(disk_location)
+    }
+}
+
+impl DiskManager for Wasm4CompatibleDisk {
+    fn read(&self) -> Result<[u8; 1024], String> {
+        let mut bytes: Vec<u8> = match fs::read(&self.0) {
             Ok(bytes) => Ok(bytes),
             Err(err) => match err.kind() {
-                ErrorKind::NotFound => fs::write(&save_path, vec![0])
+                ErrorKind::NotFound => fs::write(&self.0, vec![0])
                     .map_err(|err| err.to_string())
                     .map(|_| vec![0]),
                 _ => Err(err.to_string()),
@@ -23,5 +43,86 @@ pub fn read(save_path: PathBuf) -> Box<dyn Fn() -> Result<[u8; 1024], String>> {
         bytes
             .try_into()
             .map_err(|_| "failed to resize save file to 1024".to_string())
-    })
+    }
+
+    fn write(&self, disk: [u8; 1024]) -> Result<(), String> {
+        fs::write(&self.0, disk).map_err(|err| err.to_string())
+    }
+}
+
+/// A `DiskManager` which saves the game disk at `$DATA_DIR/wasmstation/{name}.disk`.
+///
+/// |Platform | Location                                                                                         |
+/// | ------- | ------------------------------------------------------------------------------------------------ |
+/// | Linux   | `$XDG_DATA_HOME/wasmstation/{name}.disk` or `$HOME/.local/share/wasmstation/{name}.disk`         |
+/// | macOS   | `$HOME/Library/Application Support/wasmstation/{name}.disk`                                      |
+/// | Windows | `{FOLDERID_RoamingAppData}\wasmstation\{name}.disk`                                              |
+pub struct UserwideDisk(PathBuf);
+
+impl UserwideDisk {
+    pub fn new(name: &str) -> Result<Self, io::Error> {
+        let mut location = match dirs::data_dir() {
+            Some(location) => location.join("wasmstation"),
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "no application data directory",
+                ))
+            }
+        };
+
+        fs::create_dir_all(&location)?;
+
+        location.push(name);
+        location.set_extension("disk");
+
+        Ok(Self(location))
+    }
+}
+
+impl DiskManager for UserwideDisk {
+    fn read(&self) -> Result<[u8; 1024], String> {
+        let mut bytes: Vec<u8> = match fs::read(&self.0) {
+            Ok(bytes) => Ok(bytes),
+            Err(err) => match err.kind() {
+                ErrorKind::NotFound => fs::write(&self.0, vec![0])
+                    .map_err(|err| err.to_string())
+                    .map(|_| vec![0]),
+                _ => Err(err.to_string()),
+            },
+        }?;
+
+        bytes.resize(1024, 0);
+        bytes
+            .try_into()
+            .map_err(|_| "failed to resize save file to 1024".to_string())
+    }
+
+    fn write(&self, disk: [u8; 1024]) -> Result<(), String> {
+        fs::write(&self.0, disk).map_err(|err| err.to_string())
+    }
+}
+
+/// The default disk manager, logs warning statements for every `read()`/`write()`.
+///
+/// This is created in order for [`LaunchConfig`](crate::renderer::LaunchConfig) to implement [`Default`].
+pub struct DebugDisk;
+
+impl DiskManager for DebugDisk {
+    fn read(&self) -> Result<[u8; 1024], String> {
+        log::warn!("DebugDisk used, no save disk read.");
+
+        Ok((0..1024)
+            .into_iter()
+            .map(|_| 0)
+            .collect::<Vec<u8>>()
+            .try_into()
+            .expect("wrong framebuffer size"))
+    }
+
+    fn write(&self, disk: [u8; 1024]) -> Result<(), String> {
+        log::warn!("DebugDisk used, no save disk written.");
+
+        Ok(())
+    }
 }

--- a/wasmstation/src/lib.rs
+++ b/wasmstation/src/lib.rs
@@ -8,6 +8,7 @@ pub mod wasm4;
 pub mod backend;
 pub mod console;
 pub mod renderer;
+pub mod disk;
 
 pub use renderer::launch;
 


### PR DESCRIPTION
Users of `renderer::launch` will probably want more control over the title of the window and how save files are accessed. This PR makes it so the caller of `renderer::launch` decides what is done when the game calls `diskr` and `diskw`.

Changes:
 - `renderer::launch` now takes a `Backend`, display scale, title, and two callbacks for reading and writing the save files.
 - `--save-path`/`-s` option added for the CLI.
   - The old `-s` option (display scale) has been changed to `-d` (display scale) because `-s` fits `--save-path` much better than `--display-scale`.
 - A module has been created at `cli/src/disk.rs` which holds functions that create common callbacks for writing and reading save files. This is used by the CLI and is now created in wasmstation template projects. It was not included in the main wasmstation crate because I'm trying to keep that OS-independent in the future (for embedded).
 - The CLI now imports `log` to emit a nice error message when the cart bytes can't be read. In the future I'd like to remove all instances of `.unwrap()` and `.expect()` in the CLI and have it only emit nice looking errors from `pretty_env_logger`.