### PR TITLE
Generalize `console::text` to support UTF-16

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A work-in-progress runtime for [WASM-4](https://github.com/aduros/wasm4).
 
 
 ## Short Term Goals
-* [ ] Implement all WASM-4 functions
+* [X] Implement all WASM-4 functions
   - [X] `blit`
   - [X] `blit_sub`
   - [X] `line`
@@ -16,9 +16,9 @@ A work-in-progress runtime for [WASM-4](https://github.com/aduros/wasm4).
   - [X] `tone` - sound slightly off
   - [X] `diskr`
   - [X] `diskw`
-  - [ ] `traceUtf8`
-  - [ ] `traceUtf16`
-  - [ ] `tracef`
+  - [X] `traceUtf8`
+  - [X] `traceUtf16`
+  - [X] `tracef`
 * [X] Run W4 games (carts) on desktop platforms
 * [X] Embed wasmstation into standalone game executables
 * [ ] Offer support for different renderers (wgpu, sdl2)

--- a/wasmstation/src/backend/wasmer.rs
+++ b/wasmstation/src/backend/wasmer.rs
@@ -533,12 +533,15 @@ fn text_utf16(
 ) {
     let ctx = Context::from_env(&env);
     let slice = ptr.slice(ctx.view(), length).unwrap();
-    let w4_string_utf16 = slice.read_to_vec().unwrap();
+    let w4_string = slice.read_to_vec().unwrap();
 
-    let w4_string: Vec<u8> =
-        String::from_utf16_lossy(bytemuck::cast_slice(&w4_string_utf16)).into_bytes();
-
-    console::text(&mut ctx.fb(), &w4_string, x, y, ctx.draw_colors())
+    console::text(
+        &mut ctx.fb(),
+        bytemuck::cast_slice::<u8, u16>(&w4_string),
+        x,
+        y,
+        ctx.draw_colors(),
+    )
 }
 
 fn diskr(env: FunctionEnvMut<WasmerRuntimeEnv>, dest: WasmPtr<u8>, size: u32) -> u32 {

--- a/wasmstation/src/backend/wasmer.rs
+++ b/wasmstation/src/backend/wasmer.rs
@@ -336,6 +336,14 @@ fn text_utf16(
     x: i32,
     y: i32,
 ) {
+    let ctx = Context::from_env(&env);
+    let slice = ptr.slice(ctx.view(), length).unwrap();
+    let w4_string_utf16 = slice.read_to_vec().unwrap();
+
+    let w4_string: Vec<u8> =
+        String::from_utf16_lossy(bytemuck::cast_slice(&w4_string_utf16)).into_bytes();
+
+    console::text(&mut ctx.fb(), &w4_string, x, y, ctx.draw_colors())
 }
 
 fn diskr(env: FunctionEnvMut<WasmerRuntimeEnv>, dest: WasmPtr<u8>, size: u32) -> u32 {

--- a/wasmstation/src/console/framebuffer/text.rs
+++ b/wasmstation/src/console/framebuffer/text.rs
@@ -124,11 +124,23 @@ const CHARSET: [u8; 1792] = [
 ///
 /// - The string may contain new-line (`\\n`) characters.
 /// - The font is 8x8 pixels per character.
-pub fn text<T: Source<u8> + Sink<u8>>(fb: &mut T, text: &[u8], x: i32, y: i32, draw_colors: u16) {
+pub fn text<T: Source<u8> + Sink<u8>, B: Copy + Into<usize>>(
+    fb: &mut T,
+    text: &[B],
+    x: i32,
+    y: i32,
+    draw_colors: u16,
+) {
     let (mut tx, mut ty) = (x, y);
 
     for c in text {
+        let c: usize = (*c).into();
+
         match c {
+            0 => {
+                // null-terminator
+                break;
+            }
             10 => {
                 // line feed
                 ty += 8;

--- a/wasmstation/src/console/mod.rs
+++ b/wasmstation/src/console/mod.rs
@@ -6,9 +6,7 @@ mod framebuffer;
 use core::cell::Cell;
 
 use audio::{AudioInterface, AudioState};
-pub use framebuffer::{
-    blit_sub, clear, hline, line, oval, pixel_width_of_flags, rect, text, vline,
-};
+pub use framebuffer::*;
 
 pub struct Console {
     audio_state: AudioState,


### PR DESCRIPTION
This is simple, it just adds more generics to `console::text` so it can support `&[u8]` and `&[u16]`. It also adds a check to end the string at a null terminator (something that wasm4-test-cart expects of us).

Now we pass 809 tests in wasm4-test-cart and fail 2 named "OOB". From the previews I suspect these are related to #29.