### PR TITLE
Move `tracef()` to `console` module.

### DIFF
--- a/wasmstation/src/backend/wasmer.rs
+++ b/wasmstation/src/backend/wasmer.rs
@@ -205,6 +205,15 @@ impl<'a> Context<'a> {
     }
 }
 
+impl<'a> Source<u8> for MemoryView<'a> {
+    fn item_at(&self, offset: usize) -> Option<u8> {
+        match self.read_u8(offset as u64) {
+            Ok(b) => Some(b),
+            Err(_) => None,
+        }
+    }
+}
+
 struct WasmSliceSinkSource<'a, T>
 where
     T: ValueType + Copy,
@@ -216,8 +225,11 @@ impl<'a, T> Source<T> for WasmSliceSinkSource<'a, T>
 where
     T: ValueType + Copy,
 {
-    fn item_at(&self, offset: usize) -> T {
-        self.slice.index(offset as u64).read().unwrap()
+    fn item_at(&self, offset: usize) -> Option<T> {
+        match self.slice.index(offset as u64).read() {
+            Ok(b) => Some(b),
+            Err(_) => None,
+        }
     }
 }
 
@@ -261,131 +273,17 @@ fn trace(env: FunctionEnvMut<WasmerRuntimeEnv>, ptr: WasmPtr<u8>) {
 fn tracef(env: FunctionEnvMut<WasmerRuntimeEnv>, fmt: WasmPtr<u8>, args: WasmPtr<u8>) {
     let ctx = Context::from_env(&env);
 
-    let mut fmt_offset = fmt.offset();
-    let mut arg_offset = args.offset();
+    let fmt_slice = fmt.read_utf8_string_with_nul(ctx.view()).unwrap_or_default();
 
-    let mut output = String::new();
+    // 1024 bytes should be more than enough to contain a single
+    // tracef() call's chars, f64s, f32s, and string pointers.
+    let mut arg_slice = (0..=512).map(|_| 0).collect::<Vec<u8>>();
 
-    while let Ok(ch) = ctx.view().read_u8(fmt_offset as u64) {
-        fmt_offset += 1;
+    ctx.view()
+        .read(args.offset().into(), &mut arg_slice)
+        .unwrap_or_default();
 
-        // null-terminated string
-        if ch == 0 {
-            break;
-        }
-
-        // character other than formatting character '%' is just added.
-        if ch != 37 {
-            output.push(char::from_u32(ch as u32).unwrap_or('!'));
-            continue;
-        }
-
-        // if we've hit the formatting character ('%') then move to the next
-        // char and check to see what it is. Then replace it.
-        if let Ok(ch) = ctx.view().read_u8(fmt_offset as u64) {
-            match ch {
-                // 'c' - character
-                99 => {
-                    let mut val: [u8; 4] = [0; 4];
-
-                    match WasmPtr::<u8>::new(arg_offset).slice(ctx.view(), 4) {
-                        Ok(slice) => match slice.read_slice(&mut val) {
-                            Ok(_) => (),
-                            Err(err) => {
-                                error!("failed to read char WasmSlice to slice");
-                                continue;
-                            }
-                        },
-                        Err(err) => {
-                            error!("failed to read WasmSlice from arg_offset");
-                            continue;
-                        }
-                    }
-
-                    output.push(char::from_u32(bytemuck::cast(val)).unwrap_or('!'));
-                    arg_offset += 4;
-                }
-                // 'd'/'x' - integer/hex
-                100 | 120 => {
-                    let mut val: [u8; 4] = [0; 4];
-
-                    match WasmPtr::<u8>::new(arg_offset).slice(ctx.view(), 4) {
-                        Ok(slice) => match slice.read_slice(&mut val) {
-                            Ok(_) => (),
-                            Err(err) => {
-                                error!("failed to read int WasmSlice");
-                                continue;
-                            }
-                        },
-                        Err(err) => {
-                            error!("failed to read WasmSlice from arg_offset");
-                            continue;
-                        }
-                    }
-
-                    output.push_str(&i32::from_le_bytes(val).to_string());
-                    arg_offset += 4;
-                }
-                // 's' - null terminated string
-                115 => {
-                    let mut ptr_bytes: [u8; 4] = [0; 4];
-
-                    match WasmPtr::<u8>::new(arg_offset).slice(ctx.view(), 4) {
-                        Ok(slice) => match slice.read_slice(&mut ptr_bytes) {
-                            Ok(_) => (),
-                            Err(err) => {
-                                error!("failed to read str WasmSlice");
-                                continue;
-                            }
-                        },
-                        Err(err) => {
-                            error!("failed to read WasmSlice from arg_offset");
-                            continue;
-                        }
-                    }
-
-                    let str = match WasmPtr::<u8>::new(bytemuck::cast(ptr_bytes))
-                        .read_utf8_string_with_nul(ctx.view())
-                    {
-                        Ok(str) => str,
-                        Err(err) => {
-                            error!("failed to read null terminated string");
-                            continue;
-                        }
-                    };
-
-                    output.push_str(&str);
-                    arg_offset += 4;
-                }
-                // 'f' - float
-                102 => {
-                    let mut val: [u8; 8] = [0; 8];
-
-                    match WasmPtr::<u8>::new(arg_offset).slice(ctx.view(), 8) {
-                        Ok(slice) => match slice.read_slice(&mut val) {
-                            Ok(_) => (),
-                            Err(err) => {
-                                error!("failed to read float WasmSlice");
-                                continue;
-                            }
-                        },
-                        Err(err) => {
-                            error!("failed to read WasmSlice from arg_offset");
-                            continue;
-                        }
-                    }
-
-                    output.push_str(&f64::from_le_bytes(val).to_string());
-                    arg_offset += 8;
-                }
-                _ => output.push(char::from_u32(ch as u32).unwrap_or('!')),
-            }
-
-            fmt_offset += 1;
-        }
-    }
-
-    println!("{output}");
+    println!("{}", console::tracef(&fmt_slice, &arg_slice, ctx.view()));
 }
 
 fn trace_utf8(env: FunctionEnvMut<WasmerRuntimeEnv>, ptr: WasmPtr<u8>, len: u32) {

--- a/wasmstation/src/backend/wasmer.rs
+++ b/wasmstation/src/backend/wasmer.rs
@@ -273,17 +273,7 @@ fn trace(env: FunctionEnvMut<WasmerRuntimeEnv>, ptr: WasmPtr<u8>) {
 fn tracef(env: FunctionEnvMut<WasmerRuntimeEnv>, fmt: WasmPtr<u8>, args: WasmPtr<u8>) {
     let ctx = Context::from_env(&env);
 
-    let fmt_slice = fmt.read_utf8_string_with_nul(ctx.view()).unwrap_or_default();
-
-    // 1024 bytes should be more than enough to contain a single
-    // tracef() call's chars, f64s, f32s, and string pointers.
-    let mut arg_slice = (0..=512).map(|_| 0).collect::<Vec<u8>>();
-
-    ctx.view()
-        .read(args.offset().into(), &mut arg_slice)
-        .unwrap_or_default();
-
-    println!("{}", console::tracef(&fmt_slice, &arg_slice, ctx.view()));
+    println!("{}", console::tracef(fmt.offset(), args.offset(), ctx.view()));
 }
 
 fn trace_utf8(env: FunctionEnvMut<WasmerRuntimeEnv>, ptr: WasmPtr<u8>, len: u32) {

--- a/wasmstation/src/console/framebuffer/blit.rs
+++ b/wasmstation/src/console/framebuffer/blit.rs
@@ -168,7 +168,7 @@ pub fn blit_sub_multipixel<S, T>(
             // if there's room in pixbuf, get next sprite byte
             if pixbuf_len < 8 && sprite_pixels_left > 0 {
                 // load next u8 from sprite line
-                let sprite_byte = sprite.item_at(sprite_idx);
+                let sprite_byte = sprite.item_at(sprite_idx).unwrap();
                 sprite_idx += 1;
 
                 let sprite_word;
@@ -211,7 +211,7 @@ pub fn blit_sub_multipixel<S, T>(
             pixbuf_len -= 8;
 
             // apply src_byte to target byte in frame buffer
-            let mut tgt_byte = target.item_at(n as usize);
+            let mut tgt_byte = target.item_at(n as usize).unwrap();
             tgt_byte &= mask_byte;
             tgt_byte |= src_byte;
             target.set_item_at(n as usize, tgt_byte)
@@ -232,12 +232,12 @@ fn get_sprite_pixel_draw_color<T: Source<u8>>(
     let pixel_index = width * y + x;
     match fmt {
         PixelFormat::Blit1BPP => {
-            let mut byte = sprite.item_at((pixel_index >> 3) as usize);
+            let mut byte = sprite.item_at((pixel_index >> 3) as usize).unwrap();
             byte = byte >> (7 - (pixel_index & 0x07));
             byte & 0x01
         }
         PixelFormat::Blit2BPP => {
-            let mut byte = sprite.item_at((pixel_index >> 2) as usize);
+            let mut byte = sprite.item_at((pixel_index >> 2) as usize).unwrap();
             byte = byte >> (6 - ((pixel_index & 0x03) << 1));
             byte & 0x03
         }

--- a/wasmstation/src/console/framebuffer/mod.rs
+++ b/wasmstation/src/console/framebuffer/mod.rs
@@ -114,7 +114,7 @@ pub(crate) fn set_pixel_impl<S: Screen>(s: &mut S, x: i32, y: i32, color: u8) {
     let shift = (x & 0x3) << 1;
     let mask = 0x3 << shift;
 
-    let fb_byte = s.fb().item_at(idx);
+    let fb_byte = s.fb().item_at(idx).unwrap();
     s.fb_mut()
         .set_item_at(idx, (color << shift) | (fb_byte & !mask));
 }

--- a/wasmstation/src/console/mod.rs
+++ b/wasmstation/src/console/mod.rs
@@ -2,11 +2,13 @@
 
 mod audio;
 mod framebuffer;
+mod trace;
 
 use core::cell::Cell;
 
 use audio::{AudioInterface, AudioState};
 pub use framebuffer::*;
+pub use trace::tracef;
 
 pub struct Console {
     audio_state: AudioState,

--- a/wasmstation/src/console/trace.rs
+++ b/wasmstation/src/console/trace.rs
@@ -3,13 +3,10 @@ use crate::Source;
 /// Parse a formatted string.
 ///
 /// Arguments:
-///  - `fmt: u32`: a pointer to the format string (**null terminated ASCII**).
-///  - `args: u32`: a pointer to the data arguments.
+///  - `fmt: usize`: a pointer to the format string (**null terminated ASCII**).
+///  - `args: usize`: a pointer to the data arguments.
 ///  - `mem: &impl Source<u8>`: a reference to the game's memory.
-pub fn tracef<T: Source<u8>>(fmt: u32, args: u32, mem: &T) -> String {
-    let mut fmt = fmt as usize;
-    let mut args = args as usize;
-
+pub fn tracef<T: Source<u8>>(mut fmt: usize, mut args: usize, mem: &T) -> String {
     let mut fmt_str = String::new();
 
     while let Some(b) = mem.item_at(fmt) {
@@ -42,34 +39,28 @@ pub fn tracef<T: Source<u8>>(fmt: u32, args: u32, mem: &T) -> String {
         if let Some(ch) = fmt_chars.next() {
             match ch {
                 'c' => {
-                    let val = u32::from_le_bytes([
-                        mem.item_at(args).unwrap_or(0),
-                        mem.item_at(args + 1).unwrap_or(0),
-                        mem.item_at(args + 2).unwrap_or(0),
-                        mem.item_at(args + 3).unwrap_or(0),
-                    ]);
+                    let val = match mem.items_at(args) {
+                        Some(val) => u32::from_le_bytes(val),
+                        None => continue,
+                    };
 
                     output.push(val.try_into().unwrap_or('!'));
                     args += 4;
                 }
                 'd' | 'x' => {
-                    let val = i32::from_le_bytes([
-                        mem.item_at(args).unwrap_or(0),
-                        mem.item_at(args + 1).unwrap_or(0),
-                        mem.item_at(args + 2).unwrap_or(0),
-                        mem.item_at(args + 3).unwrap_or(0),
-                    ]);
+                    let val = match mem.items_at(args) {
+                        Some(bytes) => i32::from_le_bytes(bytes),
+                        None => continue,
+                    };
 
                     output.push_str(&val.to_string());
                     args += 4;
                 }
                 's' => {
-                    let mut str_ptr = u32::from_le_bytes([
-                        mem.item_at(args).unwrap_or(0),
-                        mem.item_at(args + 1).unwrap_or(0),
-                        mem.item_at(args + 2).unwrap_or(0),
-                        mem.item_at(args + 3).unwrap_or(0),
-                    ]);
+                    let mut str_ptr = match mem.items_at(args) {
+                        Some(val) => u32::from_le_bytes(val),
+                        None => continue,
+                    };
 
                     let mut nstr = String::new();
 
@@ -86,16 +77,10 @@ pub fn tracef<T: Source<u8>>(fmt: u32, args: u32, mem: &T) -> String {
                     args += 4;
                 }
                 'f' => {
-                    let val = f64::from_le_bytes([
-                        mem.item_at(args).unwrap_or(0),
-                        mem.item_at(args + 1).unwrap_or(0),
-                        mem.item_at(args + 2).unwrap_or(0),
-                        mem.item_at(args + 3).unwrap_or(0),
-                        mem.item_at(args + 4).unwrap_or(0),
-                        mem.item_at(args + 5).unwrap_or(0),
-                        mem.item_at(args + 6).unwrap_or(0),
-                        mem.item_at(args + 7).unwrap_or(0),
-                    ]);
+                    let val = match mem.items_at(args) {
+                        Some(val) => f64::from_le_bytes(val),
+                        None => continue,
+                    };
 
                     output.push_str(&val.to_string());
                     args += 8;

--- a/wasmstation/src/console/trace.rs
+++ b/wasmstation/src/console/trace.rs
@@ -1,0 +1,155 @@
+use log::error;
+
+use crate::Source;
+
+/// Parse a formatted string.
+///
+/// Arguments:
+/// - `fmt: &str`: the format string (with '%' characters).
+/// - `args: &[u8]`: bytes containing argument values after the argument pointer.
+/// - `mem: impl Source<u8>`: a reference to the cart's memory. This is used to access inserted strings.
+pub fn tracef<T: Source<u8>>(fmt: &str, args: &[u8], mem: &T) -> String {
+    let mut arg_idx = 0;
+    let mut fmt = fmt.chars();
+
+    let mut output = String::new();
+
+    while let Some(ch) = fmt.next() {
+        // break on null terminated string.
+        if ch == '\0' {
+            break;
+        }
+
+        // characters other than formatting character '%' are just added.
+        if ch != '%' {
+            output.push(ch);
+            continue;
+        }
+
+        // if we've hit the formatting character ('%') then move to the next
+        // char and check to see what it is and replace it with the value it references.
+        if let Some(ch) = fmt.next() {
+            match ch {
+                'c' => {
+                    let val: u32 = match args
+                        .get(arg_idx..(arg_idx + 4))
+                        .map(|s| s.try_into().unwrap())
+                    {
+                        Some(bytes) => u32::from_le_bytes(bytes),
+                        None => {
+                            error!("failed to read char at {arg_idx}");
+                            break;
+                        }
+                    };
+
+                    output.push(char::from_u32(val).unwrap_or('!'));
+                    arg_idx += 4;
+                }
+                'd' | 'x' => {
+                    let val: i32 = match args
+                        .get(arg_idx..(arg_idx + 4))
+                        .map(|s| s.try_into().unwrap())
+                    {
+                        Some(bytes) => i32::from_le_bytes(bytes),
+                        None => {
+                            error!("failed to read i32 at {arg_idx}");
+                            break;
+                        }
+                    };
+
+                    output.push_str(&val.to_string());
+                    arg_idx += 4;
+                }
+                's' => {
+                    let mut str_ptr: u32 = match args
+                        .get(arg_idx..(arg_idx + 4))
+                        .map(|s| s.try_into().unwrap())
+                    {
+                        Some(bytes) => u32::from_le_bytes(bytes),
+                        None => {
+                            error!("failed to read ptr at {arg_idx}");
+                            break;
+                        }
+                    };
+
+                    let mut nstr = String::new();
+
+                    while let Some(byte) = mem.item_at(str_ptr as usize) {
+                        if byte == 0 {
+                            break;
+                        }
+
+                        nstr.push(byte.try_into().unwrap_or('!'));
+                        str_ptr += 1;
+                    }
+
+                    output.push_str(&nstr);
+                    arg_idx += 4;
+                }
+                'f' => {
+                    let val: f64 = match args
+                        .get(arg_idx..(arg_idx + 8))
+                        .map(|s| s.try_into().unwrap())
+                    {
+                        Some(bytes) => f64::from_le_bytes(bytes),
+                        None => {
+                            error!("failed to read f64 at {arg_idx}");
+                            break;
+                        }
+                    };
+
+                    output.push_str(&val.to_string());
+                    arg_idx += 8;
+                }
+                _ => output.push(ch),
+            }
+        }
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tracef;
+
+    #[test]
+    fn tracef_float() {
+        assert_eq!(
+            "0.473;0.856",
+            tracef("%f;%f", bytemuck::cast_slice(&[0.473, 0.856]), &[])
+        );
+    }
+
+    #[test]
+    fn tracef_int() {
+        assert_eq!(
+            "4082;8088",
+            tracef("%d;%d", bytemuck::cast_slice(&[4082i32, 8088i32]), &[])
+        )
+    }
+
+    #[test]
+    fn tracef_str() {
+        assert_eq!(
+            "here's your str: 'inner string!'",
+            tracef(
+                "here's your str: '%s'",
+                bytemuck::cast_slice(&[11u32]),
+                &"before the inner string!".as_bytes().to_vec()
+            )
+        )
+    }
+
+    #[test]
+    fn tracef_char() {
+        assert_eq!(
+            "exclamation mark: !; ampersand: &",
+            tracef(
+                "exclamation mark: %c; ampersand: %c",
+                bytemuck::cast_slice::<char, u8>(&['!', '&']),
+                &[]
+            )
+        )
+    }
+}

--- a/wasmstation/src/lib.rs
+++ b/wasmstation/src/lib.rs
@@ -53,23 +53,30 @@ where
     /// Read memory at the specified offset, relative to the start
     /// of the memory subregion the [`Source<T>`] covers.
     fn item_at(&self, offset: usize) -> Option<T>;
+
+    /// Like [`items_at`](Source::items_at), but reads multiple values.
+    fn items_at<const L: usize>(&self, offset: usize) -> Option<[T; L]>;
 }
 
-impl<T> Source<T> for Vec<T>
-where
-    T: Copy,
-{
+impl<T: Copy> Source<T> for Vec<T> {
     fn item_at(&self, offset: usize) -> Option<T> {
         self.get(offset).map(|b| *b)
     }
+
+    fn items_at<const L: usize>(&self, offset: usize) -> Option<[T; L]> {
+        self.get(offset..(offset + L))
+            .map(|s| s.try_into().unwrap())
+    }
 }
 
-impl<const N: usize, T> Source<T> for [T; N]
-where
-    T: Copy,
-{
+impl<const N: usize, T: Copy> Source<T> for [T; N] {
     fn item_at(&self, offset: usize) -> Option<T> {
         self.get(offset).map(|b| *b)
+    }
+
+    fn items_at<const L: usize>(&self, offset: usize) -> Option<[T; L]> {
+        self.get(offset..(offset + L))
+            .map(|s| s.try_into().unwrap())
     }
 }
 

--- a/wasmstation/src/lib.rs
+++ b/wasmstation/src/lib.rs
@@ -52,7 +52,25 @@ where
 {
     /// Read memory at the specified offset, relative to the start
     /// of the memory subregion the [`Source<T>`] covers.
-    fn item_at(&self, offset: usize) -> T;
+    fn item_at(&self, offset: usize) -> Option<T>;
+}
+
+impl<T> Source<T> for Vec<T>
+where
+    T: Copy,
+{
+    fn item_at(&self, offset: usize) -> Option<T> {
+        self.get(offset).map(|b| *b)
+    }
+}
+
+impl<const N: usize, T> Source<T> for [T; N]
+where
+    T: Copy,
+{
+    fn item_at(&self, offset: usize) -> Option<T> {
+        self.get(offset).map(|b| *b)
+    }
 }
 
 /// Common trait for writing to game memory.
@@ -95,23 +113,5 @@ where
 
     fn fill(&mut self, item: T) {
         <[T]>::fill(self, item)
-    }
-}
-
-impl<T> Source<T> for Vec<T>
-where
-    T: Copy,
-{
-    fn item_at(&self, offset: usize) -> T {
-        self[offset]
-    }
-}
-
-impl<const N: usize, T> Source<T> for [T; N]
-where
-    T: Copy,
-{
-    fn item_at(&self, offset: usize) -> T {
-        self[offset]
     }
 }


### PR DESCRIPTION
@upachler, `tracef()` isn't very suited to abstraction like this 😅.

 - `Source::item_at` now returns `Option<T>` instead of `T`. This is required to reliably read nul-terminated strings and is just better practice in general.
 - Added `Source::items_at`, which makes it easy to retrieve arrays from the overall memory. This is used to easily extract values other than single bytes.
 - I added some tests at `console::trace::tests` which test the int, char, string, and float functionality. They aren't very rigorous but I think they prove that it works as intended.